### PR TITLE
fix: resolve UnboundLocalError for cfg variable

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,12 +30,20 @@ def main():
     st.set_page_config(page_title='PortoDash', layout='wide')
     st.title('PortoDash — Portfolio Tracker')
 
+    # Load portfolio first
+    try:
+        cfg = load_portfolio(PORTFOLIO_PATH)
+    except Exception as e:
+        st.error(f'Failed to load portfolio.json: {e}')
+        return
+
+    holdings = cfg.get('holdings', [])
+
     # Sidebar
     st.sidebar.header('Controls')
     days = st.sidebar.slider('Days for performance', min_value=7, max_value=365, value=30, step=1)
     
     # Account filter
-    holdings = cfg.get('holdings', [])
     all_accounts = sorted(set(h.get('account', 'Default') for h in holdings))
     selected_account = st.sidebar.selectbox(
         'Filter by Account',
@@ -44,15 +52,6 @@ def main():
     )
     
     refresh = st.sidebar.button('Refresh prices')
-
-    # Load portfolio
-    try:
-        cfg = load_portfolio(PORTFOLIO_PATH)
-    except Exception as e:
-        st.error(f'Failed to load portfolio.json: {e}')
-        return
-
-    holdings = cfg.get('holdings', [])
     
     # Apply account filter
     if selected_account != 'All Accounts':


### PR DESCRIPTION
## Problem
The app was crashing on startup with `UnboundLocalError: cannot access local variable cfg where it is not associated with a value`.

## Root Cause
The `cfg` variable was being referenced in the sidebar account filter setup (line 38) before it was loaded from the portfolio file (line 48).

## Solution
Moved the `load_portfolio()` call to the top of the `main()` function, immediately after setting page config. This ensures `cfg` is available before any sidebar controls try to use it.

## Testing
Verified the app now launches without errors and the account filter dropdown works correctly.

---
**Note:** This PR is created by @regisca-bot for review by @RegisCA.