### PR TITLE
Switch to Financial Modeling Prep API as primary data source

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,9 @@
-# Alpha Vantage API Key (free tier: 500 req/day)
+# Financial Modeling Prep API key (primary data source)
+# Free tier: 250 requests/hour
+# Get your API key at https://site.financialmodelingprep.com/developer/docs/
+FMP_API_KEY=your_fmp_api_key_here
+
+# Alpha Vantage API Key (deprecated - only 25 requests/day)
 # Get your key from: https://www.alphavantage.co/support/#api-key
 ALPHAVANTAGE_API_KEY=your_api_key_here
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Lightweight Streamlit portfolio tracker using yfinance, pandas and Plotly.
 Features (Phase 1):
 
 - Load holdings from `portfolio.json` (private file, not tracked in git)
-- Fetch current prices using `yfinance` on page load
+- Fetch current prices using **Financial Modeling Prep API** (primary) with fallback to **yfinance** for reliability
 - Portfolio summary table with cost, current value and gains
 - Allocation pie chart (Plotly)
 - 30-day performance line chart (Plotly)
@@ -49,6 +49,14 @@ Notes:
 
 ## Installation
 
+### Prerequisites
+
+1. **Get a Financial Modeling Prep API Key** (recommended):
+   - Visit [financialmodelingprep.com](https://site.financialmodelingprep.com/developer/docs/)
+   - Sign up for a free account (no credit card required)
+   - Copy your API key from the dashboard
+   - Free tier includes 250 requests/hour (more than sufficient for portfolio tracking)
+
 ### Quick Start with venv
 
 1. Create and activate a Python environment (recommended). On macOS use `python3` (many systems don't have a `python` alias):
@@ -65,7 +73,21 @@ source .venv/bin/activate
 python -m pip install -r requirements.txt
 ```
 
-1. Start the app:
+2. **Configure environment variables**:
+
+```bash
+cp .env.sample .env
+```
+
+Edit `.env` and add your FMP API key:
+
+```bash
+FMP_API_KEY=your_fmp_api_key_here
+```
+
+The app will work without an API key using cached data, but fresh price updates require the FMP key.
+
+3. Start the app:
 
 ```bash
 streamlit run app.py

--- a/portodash/fmp.py
+++ b/portodash/fmp.py
@@ -1,0 +1,99 @@
+"""Financial Modeling Prep (FMP) API integration for stock quotes.
+
+Free tier: 250 requests/hour
+API Key: Get from https://site.financialmodelingprep.com/developer/docs/pricing
+Documentation: https://site.financialmodelingprep.com/developer/docs
+"""
+import os
+import logging
+from typing import Dict, Optional, List
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def get_fmp_api_key() -> Optional[str]:
+    """Get FMP API key from environment variable."""
+    return os.environ.get('FMP_API_KEY')
+
+
+def fetch_batch_quotes_fmp(tickers: List[str], api_key: str) -> Dict[str, Optional[float]]:
+    """Fetch current prices for multiple tickers from FMP using batch quote endpoint.
+    
+    This is the most efficient method - fetches all tickers in a single API call.
+    
+    Args:
+        tickers: List of ticker symbols (supports both US and TSX with .TO suffix)
+        api_key: FMP API key
+    
+    Returns:
+        Dictionary mapping ticker -> price (or None if unavailable)
+    """
+    prices = {t: None for t in tickers}
+    
+    if not tickers:
+        return prices
+    
+    try:
+        # FMP batch quote endpoint - all tickers in one call
+        symbols = ','.join(tickers)
+        url = f'https://financialmodelingprep.com/api/v3/quote/{symbols}'
+        params = {'apikey': api_key}
+        
+        logger.info(f"Fetching {len(tickers)} tickers from FMP batch quote API")
+        response = requests.get(url, params=params, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        
+        # Check for error messages
+        if isinstance(data, dict):
+            if 'Error Message' in data:
+                logger.error(f"FMP error: {data['Error Message']}")
+                return prices
+            if 'Information' in data:
+                # Rate limit or other info message
+                logger.warning(f"FMP info: {data['Information']}")
+                return prices
+        
+        # Parse quote data
+        if isinstance(data, list):
+            for quote in data:
+                symbol = quote.get('symbol')
+                price = quote.get('price')
+                
+                if symbol and price is not None:
+                    prices[symbol] = float(price)
+                    logger.info(f"Got {symbol} from FMP: ${price}")
+                else:
+                    logger.warning(f"No price data in FMP response for {symbol}")
+        else:
+            logger.error(f"Unexpected FMP response format: {type(data)}")
+        
+        return prices
+        
+    except requests.exceptions.Timeout:
+        logger.error("FMP request timed out after 30 seconds")
+        return prices
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Failed to fetch from FMP: {e}")
+        return prices
+    except Exception as e:
+        logger.exception(f"Unexpected error fetching from FMP: {e}")
+        return prices
+
+
+def fetch_quote_fmp(ticker: str, api_key: str) -> Optional[float]:
+    """Fetch current price for a single ticker from FMP.
+    
+    Note: For multiple tickers, use fetch_batch_quotes_fmp() instead for efficiency.
+    
+    Args:
+        ticker: Ticker symbol (supports both US and TSX with .TO suffix)
+        api_key: FMP API key
+    
+    Returns:
+        Current price or None if unavailable
+    """
+    result = fetch_batch_quotes_fmp([ticker], api_key)
+    return result.get(ticker)


### PR DESCRIPTION
## Summary
Switches from unreliable yfinance to Financial Modeling Prep (FMP) API as the primary data source for stock quotes, addressing the persistent rate limiting issues.

## Changes
- **New module**: `portodash/fmp.py` with batch quote fetching
  - `fetch_batch_quotes_fmp()`: Fetches all tickers in a single API call
  - Comprehensive error handling for timeouts, rate limits, and malformed responses
  - 30-second timeout to prevent hanging
- **Updated**: `portodash/data_fetch.py` 
  - FMP as primary data source
  - yfinance as fallback
  - Updated origins tracking to include 'fmp' source type
- **Updated**: `.env.sample` with FMP_API_KEY configuration
- **Updated**: `README.md` with FMP setup instructions and prerequisites

## Benefits
- **Reliability**: 250 requests/hour free tier vs yfinance's undocumented harsh limits
- **Efficiency**: Batch endpoint fetches all 11-12 tickers in single API call
- **No credit card**: Free tier requires no payment method
- **TSX support**: .TO suffix works directly (XEQT.TO, etc.)
- **Delayed data**: 15-30 minute delay acceptable for portfolio tracking

## Testing Required
1. Set FMP_API_KEY environment variable
2. Run test script: `python test_fmp_integration.py`
3. Launch dashboard and verify fresh prices load
4. Confirm all TSX (.TO) and US tickers fetch correctly

## Breaking Change
⚠️ Requires `FMP_API_KEY` environment variable to be set for fresh price updates. Without it, the app will fall back to yfinance (still rate-limited) and cached data.

Resolves #20